### PR TITLE
Update systems list in README.org

### DIFF
--- a/README.org
+++ b/README.org
@@ -4,6 +4,6 @@ A portable and extensible Common Lisp FORMAT implementation
 
 |---------+-------------------------------------------------------------------------------|
 | source  | git:https://github.com/s-expressionists/Invistra.git                          |
-| commit  | 61efa9d                                                                                                                                    |
-| systems | invistra invistra-numeral invistra-extrinsic invistra-extension invistra-extension-intrinsic invistra-extension-extrinsic                  |
+| commit  | 61efa9d                                                                       |
+| systems | invistra invistra-extrinsic invistra-extension invistra-extension-extrinsic   |
 |---------+-------------------------------------------------------------------------------|


### PR DESCRIPTION
invistra-numeral is no more, and the intrinsic systems probably shouldn't be in ocicl since they cannot be tested or loaded outside of a bootstrapping CL implementation.